### PR TITLE
fix: Upgrade Alpine packages to address critical vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:latest@sha256:1ba18449911d01f477a3fc104123c85d677addc60701b14b3fcb5381f9c4a537
 
-RUN apk add --no-cache curl && apk upgrade --no-cache zlib
+RUN apk add --no-cache curl && apk upgrade --no-cache zlib openssl libexpat
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
# Description
Related to: https://github.com/step-security/console/actions/runs/23030778282/job/66888498648#step:9:39

This PR fixes:
- CVE-2025-15467 (openssl - CRITICAL)                                                                                                                      
- CVE-2026-22184 (zlib - CRITICAL)                                                                                                                         
- CVE-2025-69419
- CVE-2025-69421 (openssl - HIGH)
- CVE-2026-25210 (libexpat - HIGH)